### PR TITLE
Add location class

### DIFF
--- a/lib/helpers/MembershipRequest/MembershipRequestCreator.js
+++ b/lib/helpers/MembershipRequest/MembershipRequestCreator.js
@@ -1,10 +1,16 @@
-const GeoPoint = require('geopoint')
 const MembershipRequest = require('../../models/MembershipRequest');
 
 const create = async (user, band) => {
-  hasValidInstrument(user, band)
-  isValidDistance(user.getLocation().getGeoJSON().coordinates,
-		  band.getLocation().getGeoJSON().coordinates)
+  if (!band.hasMissingInstrumentForUser(user)) {
+    throw 'No open position for user in band'
+  }
+
+  // 2 km, I figure we'd later store this on the band owner and use it in the get bands endpoint 
+  // e.g. .find().where(band.user.distance <= currentUser.distance)
+  if (user.getLocation().getDistanceTo(band.getLocation()) > 2) {
+    throw 'User is too far away from band'
+  }
+
   let membershipRequest = new MembershipRequest({
             user: user.getId(),
             band: band.getId()
@@ -12,23 +18,6 @@ const create = async (user, band) => {
   await membershipRequest.save()
   band.addMembershipRequest(membershipRequest)
   await band.save()
-}
-
-const hasValidInstrument = (user, band) => {
-  if (!band.hasMissingInstrumentForUser(user)) {
-    throw 'No open position for user in band'
-  }
-}
-
-const isValidDistance = (userCoords, bandCoords) => {
-  const userLoc = new GeoPoint(userCoords[0], userCoords[1])
-  const bandLoc = new GeoPoint(bandCoords[0], bandCoords[1])
-
-  // 2 km, I figure we'd later store this on the band owner and use it in the get bands endpoint 
-  // e.g. .find().where(band.user.distance <= currentUser.distance)
-  if (userLoc.distanceTo(bandLoc, true) > 2) {
-    throw 'User is too far away from band'
-  }
 }
 
 module.exports = create

--- a/lib/helpers/MembershipRequest/MembershipRequestCreator.test.js
+++ b/lib/helpers/MembershipRequest/MembershipRequestCreator.test.js
@@ -1,4 +1,3 @@
-const GeoPoint = require('geopoint')
 const MembershipRequestCreator = require('./MembershipRequestCreator')
 const MembershipRequest = require('../../models/MembershipRequest');
 const Band = require('../../models/Band');
@@ -16,29 +15,24 @@ beforeEach(()=>{
 })
 
 it('creates a Membership Request', async ()=>{
-  const userLocation = new Location()
-  userLocation.getGeoJSON.mockReturnValueOnce({ coordinates: [1, 2]})
-  const bandLocation = new Location()
-  bandLocation.getGeoJSON.mockReturnValueOnce({ coordinates: [3, 4]})
-
   const user = new User()
+  const userLocation = new Location()
   user.getLocation.mockReturnValue(userLocation)
   user.getId.mockReturnValue('12345')
+  userLocation.getDistanceTo.mockReturnValue(1)
 
   const band = new Band()
+  const bandLocation = new Location()
   band.getLocation.mockReturnValue(bandLocation)
   band.getId.mockReturnValue('67890')
   band.hasMissingInstrumentForUser.mockReturnValue(true)
 
-  const userGeoPoint = new GeoPoint()
-  const bandGeoPoint = new GeoPoint()
-
-  GeoPoint.mockReturnValueOnce(userGeoPoint).mockReturnValueOnce(bandGeoPoint)
-  userGeoPoint.distanceTo.mockReturnValue(1)
-
   const membershipRequest = new MembershipRequest()
+  // we use this to store the params new MembershipRequest was called with so we can
+  // check they are right
   let membershipRequestParams
   MembershipRequest.mockImplementation((params)=>{
+    // here is where it is set
     membershipRequestParams = params
     return membershipRequest
   })
@@ -46,9 +40,9 @@ it('creates a Membership Request', async ()=>{
   await MembershipRequestCreator(user, band)
 
   expect(band.hasMissingInstrumentForUser).toBeCalledWith(user)
-  expect(GeoPoint).toBeCalledWith(1, 2)
-  expect(GeoPoint).toBeCalledWith(3, 4)
-  expect(userGeoPoint.distanceTo).toBeCalledWith(bandGeoPoint, true)
+  expect(user.getLocation).toBeCalled()
+  expect(band.getLocation).toBeCalled()
+  expect(userLocation.getDistanceTo).toBeCalledWith(bandLocation)
   expect(membershipRequestParams.user).toBe(user.getId())
   expect(membershipRequestParams.band).toBe(band.getId())
   expect(membershipRequest.save).toBeCalledTimes(1)
@@ -70,29 +64,22 @@ it('throws if there is no position available in the band for the user', async ()
 
   expect(band.hasMissingInstrumentForUser).toBeCalledWith(user)
   expect(MembershipRequest).not.toBeCalled()
-  expect(GeoPoint).not.toBeCalled()
   expect(band.addMembershipRequest).not.toBeCalled()
   expect(band.save).not.toBeCalled()
 })
 
 
 it('Throws if the user is too far away from the band', async ()=>{
-  const userLocation = new Location()
-  userLocation.getGeoJSON.mockReturnValueOnce({ coordinates: [1, 2]})
-  const bandLocation = new Location()
-  bandLocation.getGeoJSON.mockReturnValueOnce({ coordinates: [3, 4]})
-
   const user = new User()
+  const userLocation = new Location()
   user.getLocation.mockReturnValue(userLocation)
 
   const band = new Band()
+  const bandLocation = new Location()
   band.getLocation.mockReturnValue(bandLocation)
   band.hasMissingInstrumentForUser.mockReturnValue(true)
 
-  const userGeoPoint = new GeoPoint()
-  const bandGeoPoint = new GeoPoint()
-  GeoPoint.mockReturnValueOnce(userGeoPoint).mockReturnValueOnce(bandGeoPoint)
-  userGeoPoint.distanceTo.mockReturnValue(3)
+  userLocation.getDistanceTo.mockReturnValue(3)
 
   try {
     await MembershipRequestCreator(user, band)
@@ -101,9 +88,7 @@ it('Throws if the user is too far away from the band', async ()=>{
   }
 
   expect(band.hasMissingInstrumentForUser).toBeCalledWith(user)
-  expect(GeoPoint).toBeCalledWith(1, 2)
-  expect(GeoPoint).toBeCalledWith(3, 4)
-  expect(userGeoPoint.distanceTo).toBeCalledWith(bandGeoPoint, true)
+  expect(userLocation.getDistanceTo).toBeCalledWith(bandLocation)
   expect(MembershipRequest).not.toBeCalled()
   expect(band.addMembershipRequest).not.toBeCalled()
   expect(band.save).not.toBeCalled()

--- a/lib/models/Location.js
+++ b/lib/models/Location.js
@@ -34,6 +34,9 @@ LocationSchema.methods = {
   },
   getId: function() {
     return this._id
+  },
+  getDistanceTo(location) {
+    return this.getGeoPoint().distanceTo(location.getGeoPoint(), true)
   }
 }
 

--- a/lib/models/Location.test.js
+++ b/lib/models/Location.test.js
@@ -1,0 +1,50 @@
+const GeoPoint = require('geopoint')
+const Location = require('./Location')
+
+jest.mock('GeoPoint')
+
+beforeEach(()=>{
+  jest.resetAllMocks()
+})
+
+it('can return a GeoPoint of its location', ()=>{
+  const location = new Location({
+    _geoJSON: {
+      type: 'Point',
+      coordinates: [90, -45]
+    },
+    _name: 'The Ocean'
+  })
+
+  const geoPoint = new GeoPoint()
+  GeoPoint.mockReturnValue(geoPoint)
+
+  expect(location.getGeoPoint()).toBe(geoPoint)
+})
+
+it('can calculate the distance between two locations', ()=>{
+  const location = new Location({
+    _geoJSON: {
+      type: 'Point',
+      coordinates: [90, -45]
+    },
+    _name: 'The Ocean'
+  })
+
+  const location2 = new Location({
+    _geoJSON: {
+      type: 'Point',
+      coordinates: [90, -45]
+    },
+    _name: 'The Ocean'
+  })
+
+  const geoPoint = new GeoPoint()
+  geoPoint.distanceTo.mockReturnValue(1)
+  const geoPoint2 = new GeoPoint()
+  GeoPoint.mockReturnValueOnce(geoPoint).mockReturnValueOnce(geoPoint2)
+
+
+  expect(location.getDistanceTo(location2)).toBe(1)
+  expect(geoPoint.distanceTo).toHaveBeenCalledWith(geoPoint2, true)
+})


### PR DESCRIPTION
I didn't like how the locations were set up, with the user and band kind of half-assedly doing it.. So I made a Location class that holds the location data and friendly name, and has the ability to make GeoPoints for calculating distance on the fly (like when making membership requests)

It kind of messed the View Bands Mongoose query, as we now have to look up locations close to the user location, then find the bands that are associated with those locations - but meh. It works.

There's a way to simulate joins in MongoDB (like in SQL, e.g. join bands and locations on the location_id field and return bands where their locations match a condition) but I'm not sure how to do that in Mongoose, and I think a massive raw Mongo query would be more of a PITA than what I chucked in here. 

Fixed up some broken tests while I was there.